### PR TITLE
Fixed the Bug to Correctly Transcribe DNA Triplets

### DIFF
--- a/src/dna/DnaSequence.java
+++ b/src/dna/DnaSequence.java
@@ -11,10 +11,10 @@ public class DnaSequence {
     }
 
     public List<String> transcribe(String dna) {
-        // TODO: fix me
+    	
         List<String> aminoAcids = new LinkedList<>();
         int i = 0;
-        while(i < dna.length()) {
+        while(i < dna.length()-2) {
             String triplet = "" + dna.charAt(i) + dna.charAt(i+1) + dna.charAt(i+2);
             try {
                 String acid = this.dnaCodon.acidFor(triplet);
@@ -22,7 +22,7 @@ public class DnaSequence {
             } catch (Exception e) {
                 // silently pass codon that does not transcribe a amino acid
             }
-            i += 1;
+            i += 3;
         }
         return aminoAcids;
     }

--- a/src/dna/DnaSequenceTest.java
+++ b/src/dna/DnaSequenceTest.java
@@ -15,5 +15,6 @@ public class DnaSequenceTest {
     @Test
     public void transcribe() {
         // TODO: implement tests
+    	
     }
 }

--- a/src/dna/DnaSequenceTest.java
+++ b/src/dna/DnaSequenceTest.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import java.util.LinkedList;
+import java.util.List;
+
 public class DnaSequenceTest {
     DnaSequence dnaSequence;
     @Before
@@ -14,7 +17,51 @@ public class DnaSequenceTest {
 
     @Test
     public void transcribe() {
-        // TODO: implement tests
+    	//creating a list to hold our expected answers
+    	List<String> expected = new LinkedList<String>();
+
+    	//testing we can transcribe one protein
+    	String dna = "GCT";
+		expected.add("ala");
+    	assertEquals(expected, dnaSequence.transcribe(dna));	
+    }
+    
+    @Test
+    public void transcribeLargeSeq() {
+    	List<String> expected = new LinkedList<String>();
+    	
+    	//trying a longer dna sequence
+    	String dna = "GCTCGCAACATCGGATATAGA";
+    	expected.add("ala");
+    	expected.add("arg");
+    	expected.add("asn");
+    	expected.add("lle");
+    	expected.add("gly");
+    	expected.add("tyr");
+    	expected.add("arg");
+    	
+    	assertEquals(expected, dnaSequence.transcribe(dna));	
+    }
+    
+    
+    @Test
+    public void transcribeNewSq() {
+    	//and just for fun
+    	List<String> expected = new LinkedList<String>();
+    	
+    	//even though this technically stops at the second triplet :)
+    	String dna = "TACTGATCGACCCCCATAATGAAA";
+    	
+    	expected.add("tyr");
+    	expected.add("stop");
+    	expected.add("ser");
+    	expected.add("thr");
+    	expected.add("pro");
+    	expected.add("lle");
+    	expected.add("met");
+    	expected.add("lys");
+    	
+    	assertEquals(expected, dnaSequence.transcribe(dna));
     	
     }
 }

--- a/src/main/Main.java
+++ b/src/main/Main.java
@@ -8,7 +8,7 @@ public class Main {
     public static void main(String[] args) {
 
         String dna = "GCTCGCAACATCGGATATAGA";
-        System.out.println("DNA: " + dna);
+    	System.out.println("DNA: " + dna);
         System.out.println("The amino acids produced by this DNA Sequence is:");
 
         DnaSequence dnaSequence = new DnaSequence();


### PR DESCRIPTION
Description:
I fixed the bug in the DNASequence class to allow for it to correctly read the triplets. While the code was reading three letters at a time, it would iterate up by one, leading to overlap.
In addition, once it had reached the last three letters of the string it continued to try to iterate up and read three more letters. This led to an error.
To fix this, I had the for loop only iterate through the string until 2 less than the length and increase i by 3 rather than 1 (to preserve the triplet pattern).

Tests:
I ran three different tests to verify the program was correctly transcribing proteins (each variations of the same test). Essentially, I was just checking that it had both preserved the triplet pattern and had correctly transcribed the protein.