### PR TITLE
fix out-of-bounds error in transcribe method

### DIFF
--- a/src/dna/DnaSequence.java
+++ b/src/dna/DnaSequence.java
@@ -13,9 +13,9 @@ public class DnaSequence {
     public List<String> transcribe(String dna) {
         // TODO: fix me
         List<String> aminoAcids = new LinkedList<>();
-        int i = 0;
+        int i = 2;
         while(i < dna.length()) {
-            String triplet = "" + dna.charAt(i) + dna.charAt(i+1) + dna.charAt(i+2);
+            String triplet = "" + dna.charAt(i-2) + dna.charAt(i-1) + dna.charAt(i);
             try {
                 String acid = this.dnaCodon.acidFor(triplet);
                 aminoAcids.add(acid);

--- a/src/dna/DnaSequence.java
+++ b/src/dna/DnaSequence.java
@@ -11,7 +11,6 @@ public class DnaSequence {
     }
 
     public List<String> transcribe(String dna) {
-        // TODO: fix me
         List<String> aminoAcids = new LinkedList<>();
         int i = 2;
         while(i < dna.length()) {


### PR DESCRIPTION
The while loop in the transcribe method in _dna/DnaSequence.java_ iterates until (not including) `i`=`dna.length()`, but the next line contains the method calls `dna.charAt(i+1)` and `dna.charAt(i+2)`, throwing an out-of-bounds error when `i`=`dna.length()-2`, and two additional out-of-bounds errors when `i`=`dna.length()-1`.
This patch adds a `+2` initial offset to `i` and a `-2` offset to the `charAt` method calls, solving this issue.