### PR TITLE
Fixed bug inside DnaSequence

### DIFF
--- a/src/dna/DnaSequence.java
+++ b/src/dna/DnaSequence.java
@@ -11,17 +11,22 @@ public class DnaSequence {
     }
 
     public List<String> transcribe(String dna) {
-        // TODO: fix me
         List<String> aminoAcids = new LinkedList<>();
         int i = 0;
-        while(i < dna.length()) {
-            String triplet = "" + dna.charAt(i) + dna.charAt(i+1) + dna.charAt(i+2);
+        while(i + 2 < dna.length()) {
+        	
+        	String triplet = "" + dna.charAt(i) + dna.charAt(i+1) + dna.charAt(i+2);
+        	
             try {
                 String acid = this.dnaCodon.acidFor(triplet);
                 aminoAcids.add(acid);
+                if (acid.equals("stop")) {
+                	break;
+                }
             } catch (Exception e) {
                 // silently pass codon that does not transcribe a amino acid
             }
+     
             i += 1;
         }
         return aminoAcids;


### PR DESCRIPTION
The method transcribe in DnaSequence no longer throws an index out-of-bounds error when there aren't three letters in the given DNA sequence left to transcribe. Instead, it now checks to see if what would be the third letter in the triplet (i + 2) is within the length of the sequence.